### PR TITLE
Fix build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM ubuntu:16.04
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --fix-missing \
+    openjdk-8-jdk-headless maven emacs-nox curl tmux openssh-client jq locales && \
+    apt-get clean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing \
-    openjdk-8-jdk-headless maven emacs-nox curl tmux openssh-client jq && \
-    apt-get clean && apt-get autoremove && \
-    rm -rf /var/lib/apt/lists/*
 
 ENV LEIN_ROOT=1
 ENV LEIN_HOME=/opt/lein


### PR DESCRIPTION
`localegen`, which is a part of the `locale` package, isn't installed in the
Ubuntu 16.04 container used as the base for this image. Thus the first RUN
command fails, and the container image is not built. This is the result of trying to build the container image from the original master branch:

```
$ docker build -t iperdomo/tmate.clj .
Sending build context to Docker daemon  139.8kB
Step 1/19 : FROM ubuntu:16.04
 ---> 4a689991aa24
Step 2/19 : RUN locale-gen en_US.UTF-8
 ---> Running in 0c9ac9d7ec9e
/bin/sh: 1: locale-gen: not found
The command '/bin/sh -c locale-gen en_US.UTF-8' returned a non-zero code: 127

$ docker --version
Docker version 17.12.1-ce, build 7390fc6

$ uname -a
Linux osgiliath 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2018-10-08) x86_64 GNU/Linux
```

We need to install the package first, and then execute the `localegen`
command and set the environment variables.